### PR TITLE
demo: trim freebsd-version output

### DIFF
--- a/demo/version.go
+++ b/demo/version.go
@@ -12,7 +12,7 @@ func FreeBSDVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	vers := strings.Split(string(version), "-")
+	vers := strings.Split(strings.TrimSpace(string(version)), "-")
 	if len(vers) < 2 {
 		return vers[0], nil
 	}


### PR DESCRIPTION
The cmd `runj demo download` failed for me on FreeBSD 13:

```shell
➜  runj git:(main) runj demo download
Found arch:  amd64
Found version:  13.0-RELEASE

Downloading image for amd64 13.0-RELEASE
 into rootfs.txz
Error: parse "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/13.0-RELEASE\n/base.txz": net/url: invalid control character in URL
Usage:
  runj demo download [flags]

Flags:
  -a, --architecture string   CPU architecture, like amd64
  -h, --help                  help for download
  -o, --output string         Output filename (default "rootfs.txz")
  -v, --version string        FreeBSD version, like 12-RELEASE
```

Running `freebsd-version` runs internally the `echo` command and the output includes a newline.

I've just trimmed the returned output of `freebsd-version`.