### PR TITLE
Properly set the controlling console

### DIFF
--- a/cmd/runj-entrypoint/main.go
+++ b/cmd/runj-entrypoint/main.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"syscall"
 
 	"github.com/containerd/console"
 	"golang.org/x/sys/unix"
@@ -120,6 +121,14 @@ func dupStdio(slavePath string) error {
 			Path: slavePath,
 			Err:  err,
 		}
+	}
+
+	if _, err := syscall.Setsid(); err != nil {
+		return err
+	}
+
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.TIOCSCTTY, uintptr(0)); err != 0 {
+		return err
 	}
 	for _, i := range []int{0, 1, 2} {
 		if err := unix.Dup2(fd, i); err != nil {


### PR DESCRIPTION
**Issue number:**
#9 


**Description of changes:**
Call setsid to create a new session and make the calling process the session leader, then call the SIOCSTTY ioctl on the console FD to set it as the controlling console.

**Testing done:**
CLI testing as is documented in the issue


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](/LICENSE).
