### PR TITLE
Shim: Implement connect() call

### DIFF
--- a/containerd/shim.go
+++ b/containerd/shim.go
@@ -844,5 +844,10 @@ func (s *service) Stats(ctx context.Context, req *task.StatsRequest) (*task.Stat
 
 func (s *service) Connect(ctx context.Context, req *task.ConnectRequest) (*task.ConnectResponse, error) {
 	log.G(ctx).WithField("req", req).Warn("CONNECT")
-	return nil, errdefs.ErrNotImplemented
+	primaryPid := s.primary.GetPID()
+
+	return &taskAPI.ConnectResponse{
+		ShimPid: uint32(os.Getpid()),
+		TaskPid: uint32(primaryPid),
+	}, nil
 }


### PR DESCRIPTION
Since https://git.io/Jzi7Z containerd uses connect() call to determine
the task pid. This call is not implemented yet, and because of that
`nerdctl run` fails with recent containerd.

This change implements the connect call.

Signed-off-by: Artem Khramov <akhramov@pm.me>