### PR TITLE
cirrus: install git-lite

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
   go_modules_cache:
     folder: .gomodcache
   setup_script:
-    - pkg install -y go golangci-lint
+    - pkg install -y git-lite go golangci-lint
     - go env -w GOMODCACHE=$(pwd)/.gomodcache
     - go mod download
   build_script:


### PR DESCRIPTION
Build was failing with:
go: missing Git command. See https://golang.org/s/gogetcmd

<!--
Tips:
- Please read CONTRIBUTING.md to understand the process for PRs.
- Please file an issue before creating a PR so we can discuss the change and
  confirm it's in line with the goals of the project.
-->

**Issue number:**



**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](/LICENSE).
