### PR TITLE
Support FreeBSD extensions to the bundle config.json

### DIFF
--- a/cmd/runj/create.go
+++ b/cmd/runj/create.go
@@ -160,12 +160,19 @@ written`)
 		} else if consoleSocket != "" {
 			return errors.New("console-socket provided but Process.Terminal is false")
 		}
-		var confPath string
-		confPath, err = jail.CreateConfig(&jail.Config{
+
+		jailcfg := &jail.Config{
 			Name:     id,
 			Root:     rootPath,
 			Hostname: ociConfig.Hostname,
-		})
+		}
+		if ociConfig.FreeBSD != nil && ociConfig.FreeBSD.Network != nil && ociConfig.FreeBSD.Network.IPv4 != nil {
+			jailcfg.IP4 = string(ociConfig.FreeBSD.Network.IPv4.Mode)
+			jailcfg.IP4Addr = ociConfig.FreeBSD.Network.IPv4.Addr
+		}
+
+		var confPath string
+		confPath, err = jail.CreateConfig(jailcfg)
 		if err != nil {
 			return err
 		}

--- a/cmd/runj/demo.go
+++ b/cmd/runj/demo.go
@@ -171,6 +171,13 @@ func exampleSpec() *runtimespec.Spec {
 			Type:        "devfs",
 			Options:     []string{"ruleset=4"},
 		}},
+		FreeBSD: &runtimespec.FreeBSD{
+			Network: &runtimespec.FreeBSDNetwork{
+				IPv4: &runtimespec.FreeBSDIPv4{
+					Mode: runtimespec.FreeBSDIPv4ModeInherit,
+				},
+			},
+		},
 	}
 }
 

--- a/docs/oci.md
+++ b/docs/oci.md
@@ -1,5 +1,56 @@
 *Placeholder for OCI changes*
 
+# FreeBSD extensions
+
+runj supports a new `freebsd` field in the `config.json` that models
+FreeBSD-specific configuration options for jails.  The `freebsd` field can also
+be written to a runj-specific `runj.ext.json` file in the bundle directory to
+allow this functionality to be tested without modifying other tools.
+
+Fields inside the `freebsd` struct:
+* `network` (struct)
+
+Fields inside the `network` struct:
+* `ipv4` (struct)
+
+Fields inside the `ipv4` struct:
+* `mode` (string) - valid options are `new`, `inherit`, and `disable`.  This
+  field is the equivalent of the `ip4` field described in the `jail(8)` manual
+  page.
+* `addr` ([]string) - list of IPv4 addresses assigned to the jail.  This field
+  is the equivalent of the `ip4.addr` field described in the `jail(8)` manual
+  page.
+
+If embedded in the normal `config.json`, an example would look as follows:
+
+```json
+{
+  "ociVersion": "1.0.2",
+  "process": {
+    // omitted
+  },
+  "freebsd": {
+    "network": {
+      "ipv4": {
+        "mode": "new",
+        "addr": ["127.0.0.2"]
+      }
+    }
+  }
+}
+```
+
+If included in a separate `runj.ext.json`, an example would look as follows:
+
+```json
+{
+  "network": {
+    "ipv4": {
+      "mode": "inherit"
+    }
+  }
+}
+```
 # `create`
 
 The `create` command is documented [in the

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.sbk.wtf/runj
 go 1.14
 
 require (
+	github.com/bxcodec/faker v2.0.1+incompatible // indirect
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/containerd/console v1.0.3-0.20210412134321-2298a9c8aead
 	github.com/containerd/containerd v1.5.13

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40Nwln+M/+faA=
+github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"io"
+	"os"
+)
+
+// CopyFile copies a file from source to dest
+func CopyFile(source, dest string, perm os.FileMode) error {
+	input, err := os.OpenFile(source, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		output.Close()
+		if err != nil {
+			os.Remove(output.Name())
+		}
+	}()
+	_, err = io.Copy(output, input)
+	return err
+}

--- a/jail/conf_test.go
+++ b/jail/conf_test.go
@@ -27,6 +27,14 @@ func TestRenderConfigGolden(t *testing.T) {
 			Root:     "/tmp/test/hostname/root",
 			Hostname: "test.hostname.example.com",
 		},
+	}, {
+		"network",
+		Config{
+			Name:    "network",
+			Root:    "/tmp/test/network/root",
+			IP4:     "new",
+			IP4Addr: []string{"one", "two", "three"},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/jail/testdata/network.conf
+++ b/jail/testdata/network.conf
@@ -1,0 +1,6 @@
+network {
+  path = "/tmp/test/network/root";
+  ip4 = "new";
+  ip4.addr = one, two, three;
+  persist;
+}

--- a/oci/config.go
+++ b/oci/config.go
@@ -8,13 +8,19 @@ import (
 	"path/filepath"
 
 	"go.sbk.wtf/runj/runtimespec"
-
 	"go.sbk.wtf/runj/state"
 )
 
 const (
 	// ConfigFileName is the name of the config file
 	ConfigFileName = "config.json"
+
+	// RunjExtensionFileName is the name of an additional file, specifying only
+	// the experimental FreeBSD section, which can be merged into the regular
+	// bundle config.  This allows for software which generates a config file
+	// unaware of FreeBSD and runj to be augmented by an additional program
+	// that specifies additional settings.
+	RunjExtensionFileName = "runj.ext.json"
 )
 
 // StoreConfig copies the config file provided in the input bundle to the state
@@ -23,12 +29,27 @@ const (
 // Any changes made to the config.json file after this operation will not have
 // an effect on the container.
 func StoreConfig(id, bundlePath string) error {
-	input, err := os.OpenFile(filepath.Join(bundlePath, ConfigFileName), os.O_RDONLY, 0)
+	err := copyFile(filepath.Join(bundlePath, ConfigFileName), filepath.Join(state.Dir(id), ConfigFileName))
+	if err != nil {
+		return err
+	}
+	extFilename := filepath.Join(bundlePath, RunjExtensionFileName)
+	if _, err = os.Stat(extFilename); err == nil {
+		err = copyFile(extFilename, filepath.Join(state.Dir(id), RunjExtensionFileName))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(source, dest string) error {
+	input, err := os.OpenFile(source, os.O_RDONLY, 0)
 	if err != nil {
 		return err
 	}
 	defer input.Close()
-	output, err := os.OpenFile(filepath.Join(state.Dir(id), ConfigFileName), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	output, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
@@ -53,5 +74,46 @@ func LoadConfig(id string) (*runtimespec.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
+	if _, err = os.Stat(filepath.Join(state.Dir(id), RunjExtensionFileName)); err == nil {
+		extData, err := ioutil.ReadFile(filepath.Join(state.Dir(id), RunjExtensionFileName))
+		if err != nil {
+			return nil, err
+		}
+		freebsd := &runtimespec.FreeBSD{}
+		err = json.Unmarshal(extData, freebsd)
+		if err != nil {
+			return nil, err
+		}
+		merge(config, freebsd)
+	}
 	return config, nil
+}
+
+// merge processes an existing spec and additional FreeBSD section to merge them
+// together.  Fields specified in the original spec are preserved except in the
+// case where they are overwritten.  Slices the FreeBSD section are appended to
+// slices specified in the original spec.
+func merge(spec *runtimespec.Spec, freebsd *runtimespec.FreeBSD) {
+	if spec == nil || freebsd == nil {
+		return
+	}
+	if spec.FreeBSD == nil {
+		spec.FreeBSD = &runtimespec.FreeBSD{}
+	}
+	if freebsd.Network != nil {
+		if spec.FreeBSD.Network == nil {
+			spec.FreeBSD.Network = &runtimespec.FreeBSDNetwork{}
+		}
+		if freebsd.Network.IPv4 != nil {
+			if spec.FreeBSD.Network.IPv4 == nil {
+				spec.FreeBSD.Network.IPv4 = &runtimespec.FreeBSDIPv4{}
+			}
+			if freebsd.Network.IPv4.Mode != "" {
+				spec.FreeBSD.Network.IPv4.Mode = freebsd.Network.IPv4.Mode
+			}
+			if len(freebsd.Network.IPv4.Addr) > 0 {
+				spec.FreeBSD.Network.IPv4.Addr = append(spec.FreeBSD.Network.IPv4.Addr, freebsd.Network.IPv4.Addr...)
+			}
+		}
+	}
 }

--- a/oci/config.go
+++ b/oci/config.go
@@ -2,11 +2,11 @@ package oci
 
 import (
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"go.sbk.wtf/runj/internal/util"
 	"go.sbk.wtf/runj/runtimespec"
 	"go.sbk.wtf/runj/state"
 )
@@ -29,38 +29,18 @@ const (
 // Any changes made to the config.json file after this operation will not have
 // an effect on the container.
 func StoreConfig(id, bundlePath string) error {
-	err := copyFile(filepath.Join(bundlePath, ConfigFileName), filepath.Join(state.Dir(id), ConfigFileName))
+	err := util.CopyFile(filepath.Join(bundlePath, ConfigFileName), filepath.Join(state.Dir(id), ConfigFileName), 0600)
 	if err != nil {
 		return err
 	}
 	extFilename := filepath.Join(bundlePath, RunjExtensionFileName)
 	if _, err = os.Stat(extFilename); err == nil {
-		err = copyFile(extFilename, filepath.Join(state.Dir(id), RunjExtensionFileName))
+		err = util.CopyFile(extFilename, filepath.Join(state.Dir(id), RunjExtensionFileName), 0600)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func copyFile(source, dest string) error {
-	input, err := os.OpenFile(source, os.O_RDONLY, 0)
-	if err != nil {
-		return err
-	}
-	defer input.Close()
-	output, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		output.Close()
-		if err != nil {
-			os.Remove(output.Name())
-		}
-	}()
-	_, err = io.Copy(output, input)
-	return err
 }
 
 // LoadConfig loads the config file stored in the state directory

--- a/oci/config_test.go
+++ b/oci/config_test.go
@@ -1,0 +1,20 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/bxcodec/faker"
+
+	"go.sbk.wtf/runj/runtimespec"
+	"gotest.tools/v3/assert"
+)
+
+func TestMergeEmpty(t *testing.T) {
+	spec := &runtimespec.Spec{}
+	freebsd := &runtimespec.FreeBSD{}
+	err := faker.FakeData(freebsd)
+	assert.NilError(t, err)
+
+	merge(spec, freebsd)
+	assert.DeepEqual(t, freebsd, spec.FreeBSD)
+}

--- a/runtimespec/config.go
+++ b/runtimespec/config.go
@@ -35,12 +35,22 @@ type Spec struct {
 
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
-	/*
-		// Hooks configures callbacks for container lifecycle events.
-		Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris"`
-		// Annotations contains arbitrary metadata for the container.
-		Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Modification by Samuel Karp
+	/*
+			// Hooks configures callbacks for container lifecycle events.
+			Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris"`
+			// Annotations contains arbitrary metadata for the container.
+			Annotations map[string]string `json:"annotations,omitempty"`
+		// End of modification
+	*/
+
+	// Modification by Samuel Karp
+	FreeBSD *FreeBSD `json:"freebsd,omitempty"`
+	// End of modification
+
+	// Modification by Samuel Karp
+	/*
 		// Linux is platform-specific configuration for Linux based containers.
 		Linux *Linux `json:"linux,omitempty" platform:"linux"`
 		// Solaris is platform-specific configuration for Solaris based containers.
@@ -132,6 +142,43 @@ type Mount struct {
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
 }
+
+// Modification by Samuel Karp
+
+// FreeBSD specifies FreeBSD-specific configuration options
+type FreeBSD struct {
+	Network *FreeBSDNetwork `json:"network,omitempty"`
+}
+
+// FreeBSDNetwork specifies how the jail's network should be configured by the
+// kernel
+type FreeBSDNetwork struct {
+	IPv4 *FreeBSDIPv4 `json:"ipv4,omitempty"`
+}
+
+// FreeBSDIPv4 encapsulates IPv4-specific jail options
+type FreeBSDIPv4 struct {
+	// Mode specifies the IPv4 mode of the jail.  Possible values are "new",
+	// "inherit", and "disable".  Setting the Addr parameter implies a value of
+	// "new".
+	Mode FreeBSDIPv4Mode `json:"mode,omitempty"`
+	// Addr is a list of IPv4 addresses assigned ot the jail.  If this is set,
+	// the jail is restricted to using only these addresses.
+	Addr []string `json:"addr,omitempty"`
+}
+
+// FreeBSDIPv4Mode describes the mode of IPv4 in the jail.  Possible values are
+// "new", "inherit", and "disable".  Setting the IPv4 Addr parameter implies a
+// value of "new".
+type FreeBSDIPv4Mode string
+
+const (
+	FreeBSDIPv4ModeNew     FreeBSDIPv4Mode = "new"
+	FreeBSDIPv4ModeInherit                 = "inherit"
+	FreeBSDIPv4ModeDisable                 = "disable"
+)
+
+// End of modification
 
 // Modification by Samuel Karp
 /*

--- a/test/integration/inside_test.go
+++ b/test/integration/inside_test.go
@@ -5,8 +5,10 @@ package integration
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"testing"
 
@@ -39,4 +41,15 @@ func TestHostname(t *testing.T) {
 	hostname, err := os.Hostname()
 	assert.NoError(t, err, "failed to retrieve hostname")
 	fmt.Println(hostname)
+}
+
+func TestLocalhostHTTPHello(t *testing.T) {
+	port := os.Getenv("TEST_PORT")
+	requestURL := fmt.Sprintf("http://127.0.0.1:%s/hello", port)
+	resp, err := http.Get(requestURL)
+	assert.NoError(t, err, "failed to get from %q", requestURL)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err, "failed to read body")
+	fmt.Println(string(body))
 }

--- a/test/integration/integ_test.go
+++ b/test/integration/integ_test.go
@@ -120,8 +120,7 @@ func TestCreateDelete(t *testing.T) {
 }
 
 func TestJailHello(t *testing.T) {
-	spec, cleanup := setupSimpleExitingJail(t)
-	defer cleanup()
+	spec := setupSimpleExitingJail(t)
 
 	spec.Process = &runtimespec.Process{
 		Args: []string{"/integ-inside", "-test.v", "-test.run", "TestHello"},
@@ -136,8 +135,7 @@ func TestJailHello(t *testing.T) {
 func TestJailEnv(t *testing.T) {
 	env := []string{"Hello=World", "FOO=bar"}
 
-	spec, cleanup := setupSimpleExitingJail(t)
-	defer cleanup()
+	spec := setupSimpleExitingJail(t)
 
 	spec.Process = &runtimespec.Process{
 		Args: []string{"/integ-inside", "-test.run", "TestEnv"},
@@ -155,8 +153,7 @@ func TestJailEnv(t *testing.T) {
 }
 
 func TestJailNullMount(t *testing.T) {
-	spec, cleanup := setupSimpleExitingJail(t)
-	defer cleanup()
+	spec := setupSimpleExitingJail(t)
 
 	volume, err := ioutil.TempDir("", "runj-integ-test-volume-"+t.Name())
 	require.NoError(t, err, "create volume")
@@ -187,8 +184,7 @@ func TestJailNullMount(t *testing.T) {
 func TestJailHostname(t *testing.T) {
 	hostname := fmt.Sprintf("%s.example", t.Name())
 
-	spec, cleanup := setupSimpleExitingJail(t)
-	defer cleanup()
+	spec := setupSimpleExitingJail(t)
 
 	spec.Hostname = hostname
 	spec.Process = &runtimespec.Process{
@@ -206,7 +202,7 @@ func TestJailHostname(t *testing.T) {
 	}
 }
 
-func setupSimpleExitingJail(t *testing.T) (runtimespec.Spec, func()) {
+func setupSimpleExitingJail(t *testing.T) runtimespec.Spec {
 	root, err := ioutil.TempDir("", "runj-integ-test-"+t.Name())
 	require.NoError(t, err, "create root")
 
@@ -215,9 +211,10 @@ func setupSimpleExitingJail(t *testing.T) (runtimespec.Spec, func()) {
 	err = util.CopyFile("bin/integ-inside", filepath.Join(root, "integ-inside"), s.Mode())
 	require.NoError(t, err, "copy inside binary")
 
+	t.Cleanup(func() { os.RemoveAll(root) })
 	return runtimespec.Spec{
 		Root: &runtimespec.Root{Path: root},
-	}, func() { os.RemoveAll(root) }
+	}
 }
 
 func assertJailPass(t *testing.T, stdout, stderr []byte) {


### PR DESCRIPTION
**Issue number:**
https://github.com/samuelkarp/runj/issues/20


**Description of changes:**
This series of commits introduces support for experimental FreeBSD extensions to the OCI runtime specification configuration.  A new `FreeBSD` struct and associated child structs were introduced to the forked copy of the `specs-go` package, runj gained support to both read those new structs from the `config.json` as well as a runj-specific `runj.ext.json` file, and the containerd shim gained support to pass a `runj.ext.json` file through to runj.

The first new extensions introduced are IPv4-related and enable jails to be run with access to the host's IPv4 network stack for an equivalent of "host networking" in Linux containers.  See the included documentation files (`README.md` and `docs/oci.md`) for details.


**Testing done:**
Manual tests, including client networking (downloading and installing packages with `pkg`) and server networking (running nginx).  New unit and integration tests.