### PR TITLE
jail: nullfs does not support mounting files - work around by copying

### DIFF
--- a/cmd/runj/create.go
+++ b/cmd/runj/create.go
@@ -185,7 +185,7 @@ written`)
 		if err := jail.CreateJail(cmd.Context(), confPath); err != nil {
 			return err
 		}
-		err = jail.Mount(ociConfig)
+		err = jail.Mount(id, ociConfig)
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ written`)
 			if err == nil {
 				return
 			}
-			jail.Unmount(ociConfig)
+			jail.Unmount(id, ociConfig)
 		}()
 
 		// Setup and start the "runj-entrypoint" helper program in order to

--- a/cmd/runj/delete.go
+++ b/cmd/runj/delete.go
@@ -59,7 +59,7 @@ func deleteCommand() *cobra.Command {
 			if ociConfig == nil {
 				return errors.New("OCI config is required")
 			}
-			err = jail.Unmount(ociConfig)
+			err = jail.Unmount(id, ociConfig)
 			if err != nil {
 				return err
 			}

--- a/jail/mount.go
+++ b/jail/mount.go
@@ -1,6 +1,7 @@
 package jail
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // Mount mounts the mounts
-func Mount(ociConfig *runtimespec.Spec) error {
+func Mount(id string, ociConfig *runtimespec.Spec) error {
 	var err error
 	unwind := make([]string, 0)
 	defer func() {
@@ -41,6 +42,18 @@ func Mount(ociConfig *runtimespec.Spec) error {
 			if err != nil {
 				return err
 			}
+			if !stat.IsDir() {
+				// Save the original file so that we can approximate Linux
+				// bind file mounts
+				saveFile(id, dest)
+				copyFile(id, m.Source, dest)
+				continue
+			}
+		} else {
+			err = createIfNotExists(dest, true)
+			if err != nil {
+				return err
+			}
 		}
 		err = m.Mount(dest)
 		if err != nil {
@@ -65,23 +78,89 @@ func createIfNotExists(path string, isDir bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE, 0755)
+	return nil
+}
+
+func saveDir(id, dest string) string {
+	return filepath.Join(filepath.Dir(dest), ".save-"+id)
+}
+
+func saveFile(id, dest string) error {
+	_, err := os.Stat(dest)
+	if err == nil {
+		save := saveDir(id, dest)
+		if err := os.MkdirAll(save, 0700); err != nil {
+			return err
+		}
+		if err := os.Rename(dest, filepath.Join(save, filepath.Base(dest))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func restoreFile(id, dest string) error {
+	save := filepath.Join(saveDir(id, dest), filepath.Base(dest))
+	_, err := os.Stat(save)
+	if err == nil {
+		if err := os.Rename(save, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+func copyFile(id, source, dest string) error {
+	in, err := os.Open(source)
 	if err != nil {
 		return err
 	}
-	f.Close()
-	return nil
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return out.Close()
 }
 
 // Unmount attempts to unmount all mounts present in the spec.  If multiple
 // errors occur, Unmount returns the first.
-func Unmount(ociConfig *runtimespec.Spec) error {
+func Unmount(id string, ociConfig *runtimespec.Spec) error {
 	var retErr error
+	saveDirs := make(map[string]bool)
 	for i := len(ociConfig.Mounts) - 1; i >= 0; i-- {
-		dest := filepath.Join(ociConfig.Root.Path, ociConfig.Mounts[i].Destination)
+		m := ociConfig.Mounts[i]
+		dest := filepath.Join(ociConfig.Root.Path, m.Destination)
+		if m.Type == "nullfs" {
+			stat, err := os.Stat(m.Source)
+			if err != nil {
+				return err
+			}
+			if !stat.IsDir() {
+				if err := os.Remove(dest); err != nil {
+					return err
+				}
+				saveDirs[saveDir(id, dest)] = true
+				restoreFile(id, dest)
+				continue
+			}
+		}
 		err := mount.Unmount(dest, 0)
 		if err != nil && retErr == nil {
 			retErr = err
+		}
+	}
+	for saveDir := range saveDirs {
+		if err := os.RemoveAll(saveDir); err != nil {
+			return err
 		}
 	}
 	return retErr


### PR DESCRIPTION
**Description of changes:**

If the destination file exists, it is moved to a .save-<ID> directory and restored on unmount to approximate the semantics of Linux bind mounts.

**Testing done:**
Extensive tests with buildah and podman that both use file mounts to inject /etc/resolv.conf and /etc/hosts into the container.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).
