### PR TITLE
add indirect module required for building in FreeBSD ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	google.golang.org/grpc v1.34.0 // indirect
+	gotest.tools/v3 v3.0.3 // indirect
 )


### PR DESCRIPTION
**Issue number:** n/a
**Description of changes:** add missing indirect dependency to allow building in FreeBSD ports tree

**Testing done:** 

- works on my machine (tm)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).

NB to build this easily, I needed to add a git tag. Doing this has the added
advantage that the FreeBSD ports infrastructure will notify me of any new tags,
to keep the port up to date.

Even a v0.0.0-alpha-12345 would be sufficient.