### PR TITLE
Fix setupIO func so it doesn't leak file descriptors

### DIFF
--- a/containerd/pio.go
+++ b/containerd/pio.go
@@ -15,8 +15,7 @@ type stdio struct {
 	stderr io.ReadWriteCloser
 }
 
-func setupIO(ctx context.Context, stdin, stdout, stderr string) (stdio, error) {
-	io := stdio{}
+func setupIO(ctx context.Context, stdin, stdout, stderr string) (io stdio, _ error) {
 	if _, err := os.Stat(stdin); err == nil {
 		io.stdin, err = fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
 		if err != nil {


### PR DESCRIPTION
Possible scenario is that something in the middle of setupIO returns error.

We do not need to call `io.Close()` inside `setupIO` in case of error, that is handled at the calling site.

**Testing done:**

None, I'm not aware of any practical way to trigger this issue.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).
