### PR TITLE
demo: fix failing base image downloads for arm

### DIFF
--- a/demo/rootfs.go
+++ b/demo/rootfs.go
@@ -21,12 +21,12 @@ import (
 )
 
 const (
-	freeBSDDownload = "https://download.freebsd.org/ftp/releases/%s/%s/base.txz"
+	freeBSDDownload = "https://download.freebsd.org/ftp/releases/%s/%s/%s/base.txz"
 )
 
 // DownloadRootfs downloads a FreeBSD root filesystem
-func DownloadRootfs(arch, version string) (io.ReadCloser, int64, error) {
-	req, err := http.Get(fmt.Sprintf(freeBSDDownload, arch, version))
+func DownloadRootfs(machine, arch, version string) (io.ReadCloser, int64, error) {
+	req, err := http.Get(fmt.Sprintf(freeBSDDownload, machine, arch, version))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/demo/version.go
+++ b/demo/version.go
@@ -26,3 +26,10 @@ func FreeBSDArch(ctx context.Context) (string, error) {
 	arch, err := cmd.Output()
 	return strings.TrimSpace(string(arch)), err
 }
+
+// FreeBSDMachine returns the current hardware platform as reported by uname(1)
+func FreeBSDMachine(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "uname", "-m")
+	arch, err := cmd.Output()
+	return strings.TrimSpace(string(arch)), err
+}

--- a/demo/version_test.go
+++ b/demo/version_test.go
@@ -22,3 +22,10 @@ func TestFreeBSDArch(t *testing.T) {
 	t.Log(arch)
 	assert.Equal(t, strings.TrimSpace(arch), arch)
 }
+
+func TestFreeBSDMachine(t *testing.T) {
+	machine, err := FreeBSDMachine(context.Background())
+	require.NoError(t, err)
+	t.Log(machine)
+	assert.Equal(t, strings.TrimSpace(machine), machine)
+}

--- a/test/integration/integ_main_test.go
+++ b/test/integration/integ_main_test.go
@@ -107,7 +107,7 @@ func prepareRootfs() error {
 }
 
 func downloadImage(machine, arch, version string, f *os.File) error {
-	fmt.Printf("Downloading image for %s %s into %s\n", arch, version, f.Name())
+	fmt.Printf("Downloading image for %s/%s %s into %s\n", machine, arch, version, f.Name())
 	rootfs, rootLen, err := demo.DownloadRootfs(machine, arch, version)
 	if err != nil {
 		return err

--- a/test/integration/integ_main_test.go
+++ b/test/integration/integ_main_test.go
@@ -68,6 +68,12 @@ func prepareRootfs() error {
 		return err
 	}
 
+	machine, err := demo.FreeBSDMachine(context.Background())
+	if err != nil {
+		return err
+	}
+	fmt.Println("Found machine: ", machine)
+
 	arch, err := demo.FreeBSDArch(context.Background())
 	if err != nil {
 		return err
@@ -87,7 +93,7 @@ func prepareRootfs() error {
 		if err != nil {
 			return err
 		}
-		err = downloadImage(arch, version, f)
+		err = downloadImage(machine, arch, version, f)
 		f.Close()
 		if err != nil {
 			return err
@@ -100,9 +106,9 @@ func prepareRootfs() error {
 	return err
 }
 
-func downloadImage(arch, version string, f *os.File) error {
+func downloadImage(machine, arch, version string, f *os.File) error {
 	fmt.Printf("Downloading image for %s %s into %s\n", arch, version, f.Name())
-	rootfs, rootLen, err := demo.DownloadRootfs(arch, version)
+	rootfs, rootLen, err := demo.DownloadRootfs(machine, arch, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand the process for PRs.
- Please file an issue before creating a PR so we can discuss the change and
  confirm it's in line with the goals of the project.
-->

**Issue number:**
#15

**Description of changes:**
This PR adds a new commandline flag `--machine` to `demo`'s sub-commands `download` and `oci-image`. This flag is then used to build release links of the form `<machine>/<arch>/<version>` to download the respective FreeBSD release. This should produce valid download links for all machine and architecture combinations, where pre-built FreeBSD base images exist.

Additionally, it also adds a new function `FreeBSDMachine` to the `demo` package, which returns the current host's hardware platform as returned by `uname -m`. This is used to get the default value, when `runj demo download` is invoked without the `--machine` flag. This should ensure that the command provides the previous behaviour. This new function is tested by a new testcase that works analogous to the already existing test for `FreeBSDArch`

**Testing done:**
~Unfortunately, I was only able to test this on my `amd64` machine. I might be able to get my hands on an arm-based system tomorrow, but in case somebody else can test it that would be greatly appreciated. :)~

**UPDATE:** I ran `make test`, `make integ-test`, `runj demo download`, and `runj demo oci-image --machine arm64 --architecture aarch64 --version 13.2-RELEASE` on a Raspberry Pi 4. Everything seems to work as expected now. The image was downloaded correctly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).
