### PR TITLE
cirrus: bump FreeBSD image version to 13.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: CI
   freebsd_instance:
-    image_family: freebsd-13-0
+    image_family: freebsd-13-2
   go_modules_cache:
     folder: .gomodcache
   setup_script:


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand the process for PRs.
- Please file an issue before creating a PR so we can discuss the change and
  confirm it's in line with the goals of the project.
-->

**Issue number:**

Fixes #44


**Description of changes:**
The CI pipeline uses FreeBSD 13.0, which reached its end-of-life in August, 2022. This causes integration tests to fail, because they try to download this outdated release from the official download servers. This commit updates the image version to FreeBSD 13.2 to fix this.


**Testing done:**




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).
