### PR TITLE
Add implicit runj.ext.json loading for nerdctl networking

### DIFF
--- a/containerd/shim.go
+++ b/containerd/shim.go
@@ -474,6 +474,10 @@ func (s *service) Create(ctx context.Context, req *task.CreateTaskRequest) (*tas
 
 func setupRunjExtension(bundle string, options *ptypes.Any) error {
 	if options == nil {
+		_, err := os.Stat(oci.ImplicitRunjExtensionPath)
+		if (!errors.Is(err, os.ErrNotExist)) {
+			return util.CopyFile(oci.ImplicitRunjExtensionPath, filepath.Join(bundle, oci.RunjExtensionFileName), 0600)
+		}
 		return nil
 	}
 	v, err := typeurl.UnmarshalAny(options)

--- a/containerd/shim.go
+++ b/containerd/shim.go
@@ -475,7 +475,7 @@ func (s *service) Create(ctx context.Context, req *task.CreateTaskRequest) (*tas
 func setupRunjExtension(bundle string, options *ptypes.Any) error {
 	if options == nil {
 		_, err := os.Stat(oci.ImplicitRunjExtensionPath)
-		if (!errors.Is(err, os.ErrNotExist)) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return util.CopyFile(oci.ImplicitRunjExtensionPath, filepath.Join(bundle, oci.RunjExtensionFileName), 0600)
 		}
 		return nil

--- a/oci/config.go
+++ b/oci/config.go
@@ -20,6 +20,9 @@ const (
 	// unaware of FreeBSD and runj to be augmented by an additional program
 	// that specifies additional settings.
 	RunjExtensionFileName = "runj.ext.json"
+
+	// New implicit path for runj.ext.json
+	ImplicitRunjExtensionPath = "/opt/etc/runj.ext.json"
 )
 
 // StoreConfig copies the config file provided in the input bundle to the state

--- a/oci/config.go
+++ b/oci/config.go
@@ -21,7 +21,7 @@ const (
 	// that specifies additional settings.
 	RunjExtensionFileName = "runj.ext.json"
 
-	// New implicit path for runj.ext.json
+	// ImplicitRunjExtensionPath is the implicit path for runj.ext.json
 	ImplicitRunjExtensionPath = "/opt/etc/runj.ext.json"
 )
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand the process for PRs.
- Please file an issue before creating a PR so we can discuss the change and
  confirm it's in line with the goals of the project.
-->

**Issue number:**



**Description of changes:**

runj implicitly loads /opt/etc/runj.ext.json if it exists. This is a tiny modification that helps with running network-enabled Linux containers via nerdctl out of the box. It is no big deal if this PR gets denied since this is my quick way of getting networking working and might not be the most ideal or elegant way of going about it.

**Testing done:**

Ex:

```
nerdctl run -it --rm --platform linux -v /etc/resolv.conf:/etc/resolv.conf curlimages/curl http://google.com/
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms found in [the LICENSE file](https://github.com/samuelkarp/runj/blob/main/LICENSE).
